### PR TITLE
Added nil check for filepath.Walk callback

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -95,6 +95,9 @@ func (w *Watcher) watchPaths() []string {
 	ignorePaths := w.ignorePaths()
 	pathMap := map[string]struct{}{}
 	filepath.Walk(w.root(), func(path string, info os.FileInfo, err error) error {
+		if info == nil {
+			return nil
+		}
 		if !info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
Sometimes, the second argument of `filepath.Walk` callback function will be nil when error occurs.
https://golang.org/pkg/path/filepath/#WalkFunc

This PR adds nil check for `os.FileInfo` before calling its function `IsDir`.
Current implementation does not handle error in `filepath.Walk`, so this PR follows this as well.